### PR TITLE
Add support for custom JSONEncoder classes

### DIFF
--- a/frictionless/metadata.py
+++ b/frictionless/metadata.py
@@ -107,7 +107,7 @@ class Metadata(helpers.ControlledDict):
         return self.copy()
 
     # NOTE: improve this code
-    def to_json(self, target=None):
+    def to_json(self, target=None, encoder_class=None):
         """Save metadata as a json
 
         Parameters:
@@ -117,10 +117,10 @@ class Metadata(helpers.ControlledDict):
             FrictionlessException: on any error
         """
         if not target:
-            return json.dumps(self.to_dict(), indent=2, ensure_ascii=False)
+            return json.dumps(self.to_dict(), indent=2, ensure_ascii=False, cls=encoder_class)
         try:
             with tempfile.NamedTemporaryFile("wt", delete=False) as file:
-                json.dump(self.to_dict(), file, indent=2, ensure_ascii=False)
+                json.dump(self.to_dict(), file, indent=2, ensure_ascii=False, cls=encoder_class)
             helpers.move_file(file.name, target)
         except Exception as exc:
             raise exceptions.FrictionlessException(self.__Error(note=str(exc))) from exc

--- a/frictionless/metadata.py
+++ b/frictionless/metadata.py
@@ -117,10 +117,14 @@ class Metadata(helpers.ControlledDict):
             FrictionlessException: on any error
         """
         if not target:
-            return json.dumps(self.to_dict(), indent=2, ensure_ascii=False, cls=encoder_class)
+            return json.dumps(
+                self.to_dict(), indent=2, ensure_ascii=False, cls=encoder_class
+            )
         try:
             with tempfile.NamedTemporaryFile("wt", delete=False) as file:
-                json.dump(self.to_dict(), file, indent=2, ensure_ascii=False, cls=encoder_class)
+                json.dump(
+                    self.to_dict(), file, indent=2, ensure_ascii=False, cls=encoder_class
+                )
             helpers.move_file(file.name, target)
         except Exception as exc:
             raise exceptions.FrictionlessException(self.__Error(note=str(exc))) from exc

--- a/frictionless/package.py
+++ b/frictionless/package.py
@@ -264,7 +264,9 @@ class Package(Metadata):
                     if not helpers.is_safe_path(resource.path):
                         continue
                     zip.write(resource.source, resource.path)
-                descriptor = json.dumps(descriptor, indent=2, ensure_ascii=False, cls=encoder_class)
+                descriptor = json.dumps(
+                    descriptor, indent=2, ensure_ascii=False, cls=encoder_class
+                )
                 zip.writestr("datapackage.json", descriptor)
         except Exception as exception:
             error = errors.PackageError(note=str(exception))

--- a/frictionless/package.py
+++ b/frictionless/package.py
@@ -242,7 +242,7 @@ class Package(Metadata):
         return result
 
     # NOTE: support multipart
-    def to_zip(self, target):
+    def to_zip(self, target, encoder_class=None):
         """Save package to a zip
 
         Parameters:
@@ -264,7 +264,7 @@ class Package(Metadata):
                     if not helpers.is_safe_path(resource.path):
                         continue
                     zip.write(resource.source, resource.path)
-                descriptor = json.dumps(descriptor, indent=2, ensure_ascii=False)
+                descriptor = json.dumps(descriptor, indent=2, ensure_ascii=False, cls=encoder_class)
                 zip.writestr("datapackage.json", descriptor)
         except Exception as exception:
             error = errors.PackageError(note=str(exception))

--- a/frictionless/resource.py
+++ b/frictionless/resource.py
@@ -605,7 +605,7 @@ class Resource(Metadata):
         return File(**options)
 
     # NOTE: support multipart
-    def to_zip(self, target):
+    def to_zip(self, target, encoder_class=None):
         """Save resource to a zip
 
         Parameters:
@@ -627,7 +627,7 @@ class Resource(Metadata):
                     if not helpers.is_safe_path(resource.path):
                         continue
                     zip.write(resource.source, resource.path)
-                descriptor = json.dumps(descriptor, indent=2, ensure_ascii=False)
+                descriptor = json.dumps(descriptor, indent=2, ensure_ascii=False, cls=encoder_class)
                 zip.writestr("dataresource.json", descriptor)
         except (IOError, zipfile.BadZipfile, zipfile.LargeZipFile) as exception:
             error = errors.ResourceError(note=str(exception))

--- a/frictionless/resource.py
+++ b/frictionless/resource.py
@@ -627,7 +627,9 @@ class Resource(Metadata):
                     if not helpers.is_safe_path(resource.path):
                         continue
                     zip.write(resource.source, resource.path)
-                descriptor = json.dumps(descriptor, indent=2, ensure_ascii=False, cls=encoder_class)
+                descriptor = json.dumps(
+                    descriptor, indent=2, ensure_ascii=False, cls=encoder_class
+                )
                 zip.writestr("dataresource.json", descriptor)
         except (IOError, zipfile.BadZipfile, zipfile.LargeZipFile) as exception:
             error = errors.ResourceError(note=str(exception))


### PR DESCRIPTION
# Overview

Several methods like `to_zip` and `to_json` lack the ability to encode custom
or non-standard objects, such as `uuid.UUID` for example. These would have to be encoded
upfront, before calling these methods.
This commit adds a new keyword argument to pass through to the `json.dump` call for custom
`JSONEncoder` class support.

---

Please preserve this line to notify @roll (lead of this repository)
